### PR TITLE
Detect systemd service failure

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -69,8 +69,8 @@ ynh_use_logrotate
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log"
-ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log"
+ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log" --line_match="Loki started"
+ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log" --line_match="server listening on addresses"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -48,8 +48,8 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log"
-ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log"
+ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log" --line_match="Loki started"
+ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log" --line_match="server listening on addresses"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -80,8 +80,8 @@ ynh_use_logrotate --non-append
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log"
-ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log"
+ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/loki.log" --line_match="Loki started"
+ynh_systemd_action --service_name="$app-promtail" --action="start" --log_path="/var/log/$app/promtail.log" --line_match="server listening on addresses"
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- The service may not start and the CI is not aware of this

## Solution

- Look for some pattern in logs to check if the service started correctly

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
